### PR TITLE
[Backstage] Update owner for consistency

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -9,7 +9,7 @@ metadata:
 
 spec:
   type: library
-  owner: group:elastic-agent-control-plane
+  owner: group:ingest-fp
   system: platform-ingest
   lifecycle: production
 ---


### PR DESCRIPTION
This PR updates the `owner` field in the `catalog-info.yml` used by Backstage to catalog various repositories at Elastic. The updated owner is consistent with the owner of other repositories owned by the Ingest Fleet Platform team such as [elastic-agent](https://github.com/elastic/elastic-agent/blob/c5e9707328c49220b5aae41e58ce00ede3bff8f1/catalog-info.yaml#L14), [beats](https://github.com/elastic/beats/blob/c559b1a6b0e104a6d32899b7ac277faa16f0d992/catalog-info.yaml#L16), [fleet-server](https://github.com/elastic/fleet-server/blob/060d8e2925b52418b5fd477920020c59506a617f/catalog-info.yaml#L14), [elastic-agent-autodiscover](https://github.com/elastic/elastic-agent-autodiscover/blob/21e23a529bcdd33e94086583e909f9ea89367ed6/catalog-info.yaml#L11), [elastic-agent-client](https://github.com/elastic/elastic-agent-client/blob/dd646033eae6ef77cf6ff5d297e0d5513d08ac7f/catalog-info.yaml#L11), [elastic-agent-changelog-tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/0d91ef40396737228e43a7d535913732c70d4f16/catalog-info.yaml#L12), etc.