### PR TITLE
Added HasCaptureGroups

### DIFF
--- a/grok.go
+++ b/grok.go
@@ -117,6 +117,16 @@ func (grok *Grok) AddPatterns(patternDefinitions map[string]string) {
 	}
 }
 
+func (grok *Grok) HasCaptureGroups() bool {
+	for _, groupName := range grok.re.SubexpNames() {
+		if groupName != "" {
+			return true
+		}
+	}
+
+	return false
+}
+
 func (grok *Grok) Compile(pattern string, namedCapturesOnly bool) error {
 	return grok.compile(pattern, namedCapturesOnly)
 }

--- a/grok.go
+++ b/grok.go
@@ -118,6 +118,10 @@ func (grok *Grok) AddPatterns(patternDefinitions map[string]string) {
 }
 
 func (grok *Grok) HasCaptureGroups() bool {
+	if grok == nil || grok.re == nil {
+		return false
+	}
+
 	for _, groupName := range grok.re.SubexpNames() {
 		if groupName != "" {
 			return true

--- a/grok_test.go
+++ b/grok_test.go
@@ -453,3 +453,26 @@ func TestDefaultPatterns(t *testing.T) {
 		}
 	}
 }
+
+func TestCaptureGroups(t *testing.T) {
+	testCases := []struct {
+		pattern              string
+		nco                  bool
+		containsCaptureGroup bool
+	}{
+		{`\b\w+\b`, true, false},
+		{`\b\w+\b`, false, false},
+		{`%{WORD}`, true, false},
+		{`%{WORD}`, false, true},
+		{`%{SYSLOGTIMESTAMP:timestamp}`, true, true},
+		{`%{SYSLOGTIMESTAMP:timestamp}`, false, true},
+	}
+
+	for i, tt := range testCases {
+		t.Run(fmt.Sprintf("test-case-%d", i), func(t *testing.T) {
+			g := grok.NewComplete()
+			g.Compile(tt.pattern, tt.nco)
+			require.Equal(t, tt.containsCaptureGroup, g.HasCaptureGroups())
+		})
+	}
+}


### PR DESCRIPTION
Used in clients for checking if named capture groups are present in a resulting regexp when `namedCapturesOnly` is used.
This way they can skip parse completely or return error