### PR TITLE
perf: reduce grok parse allocations

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,9 +93,9 @@ err := g.Compile("%{NGINX_HOST}", true)
 res, err := g.ParseTypedString("127.0.0.1:1234")
 ```
 
-See type changed from `map[string]string` to `map[string]interface{}` and `destination.port` is now a number:
+See type changed from `map[string]string` to `map[string]any` and `destination.port` is now a number:
 ```go
-map[string]interface {} {
+map[string]any {
     "destination.ip": "127.0.0.1", 
     "destination.port": 1234, 
 }

--- a/grok.go
+++ b/grok.go
@@ -51,10 +51,9 @@ type Grok struct {
 }
 
 type captureField struct {
-	index      int
-	regexpName string
-	name       string
-	valueType  captureValueType
+	index     int
+	name      string
+	valueType captureValueType
 }
 
 type captureValueType uint8
@@ -208,6 +207,11 @@ func (grok *Grok) compile(pattern string, namedCapturesOnly bool) error {
 		return err
 	}
 
+	if grok.re != nil && grok.re.String() == expandedExpression {
+		grok.captureFields = buildCaptureFields(grok.re, hints)
+		return nil
+	}
+
 	compiledExpression, err := regexp.Compile(expandedExpression)
 	if err != nil {
 		return err
@@ -343,13 +347,13 @@ func (grok *Grok) convertMatch(match string, field captureField) (any, error) {
 	case captureValueBool:
 		return strconv.ParseBool(match)
 	default:
-		return nil, fmt.Errorf("invalid type for %v: %w", field.regexpName, ErrTypeNotProvided)
+		return nil, fmt.Errorf("invalid type for %v: %w", strings.ReplaceAll(field.name, ".", dotSep), ErrTypeNotProvided)
 	}
 }
 
 func buildCaptureFields(re *regexp.Regexp, hints map[string]string) []captureField {
 	names := re.SubexpNames()
-	fields := make([]captureField, 0, len(names))
+	fields := make([]captureField, 0, re.NumSubexp())
 	for index, regexpName := range names {
 		if regexpName == "" {
 			continue
@@ -360,10 +364,9 @@ func buildCaptureFields(re *regexp.Regexp, hints map[string]string) []captureFie
 			valueType = captureValueTypeForHint(hint)
 		}
 		fields = append(fields, captureField{
-			index:      index,
-			regexpName: regexpName,
-			name:       strings.ReplaceAll(regexpName, dotSep, "."),
-			valueType:  valueType,
+			index:     index,
+			name:      strings.ReplaceAll(regexpName, dotSep, "."),
+			valueType: valueType,
 		})
 	}
 	return fields
@@ -392,24 +395,24 @@ func (grok *Grok) expand(pattern string, namedCapturesOnly bool) (string, map[st
 	// recursion break is guarding against cyclic reference in pattern definitions
 	// as this is performed only once at compile time more clever optimization (e.g detecting cycles in graph) is TBD
 	for recursionBreak := 1000; recursionBreak > 0; recursionBreak-- {
-		matches := reusePattern.FindAllStringSubmatchIndex(expandedPattern, -1)
-		if len(matches) == 0 {
+		match := reusePattern.FindStringSubmatchIndex(expandedPattern)
+		if match == nil {
 			// nothing to expand anymore
 			break
 		}
 
 		var b strings.Builder
 		b.Grow(len(expandedPattern))
-		var last int
+		var offset int
 
-		for _, match := range matches {
+		for match != nil {
 			// grok can be specified in either of these forms:
 			// %{SYNTAX} - e.g {NUMBER}
 			// %{SYNTAX:ID} - e.g {NUMBER:MY_AGE}
 			// %{SYNTAX:ID:TYPE} - e.g {NUMBER:MY_AGE:INT}
 
 			// match[2]:match[3] is the inner "SYNTAX:ID:TYPE" part.
-			grokId, targetId, typeHint, hasTarget, hasType := parseGrokName(expandedPattern[match[2]:match[3]])
+			grokId, targetId, typeHint, hasTarget, hasType := parseGrokName(expandedPattern[offset+match[2] : offset+match[3]])
 
 			knownPattern, found := grok.lookupPattern(grokId)
 			if !found {
@@ -423,7 +426,7 @@ func (grok *Grok) expand(pattern string, namedCapturesOnly bool) (string, map[st
 				hints[targetId] = typeHint
 			}
 
-			b.WriteString(expandedPattern[last:match[0]])
+			b.WriteString(expandedPattern[offset : offset+match[0]])
 			if namedCapturesOnly && !hasTarget {
 				// this has no semantic (pattern:foo) so we don't need to capture;
 				// a non-capturing group keeps the regexp engine from tracking it
@@ -437,9 +440,10 @@ func (grok *Grok) expand(pattern string, namedCapturesOnly bool) (string, map[st
 				b.WriteString(knownPattern)
 				b.WriteByte(')')
 			}
-			last = match[1]
+			offset += match[1]
+			match = reusePattern.FindStringSubmatchIndex(expandedPattern[offset:])
 		}
-		b.WriteString(expandedPattern[last:])
+		b.WriteString(expandedPattern[offset:])
 		expandedPattern = b.String()
 	}
 

--- a/grok.go
+++ b/grok.go
@@ -46,9 +46,26 @@ var (
 type Grok struct {
 	patternDefinitions    map[string]string
 	re                    *regexp.Regexp
-	typeHints             map[string]string
+	captureFields         []captureField
 	lookupDefaultPatterns bool
 }
+
+type captureField struct {
+	index      int
+	regexpName string
+	name       string
+	valueType  captureValueType
+}
+
+type captureValueType uint8
+
+const (
+	captureValueString captureValueType = iota
+	captureValueFloat
+	captureValueInt
+	captureValueBool
+	captureValueInvalid
+)
 
 func New() *Grok {
 	return &Grok{
@@ -139,14 +156,7 @@ func (grok *Grok) HasCaptureGroups() bool {
 	if grok == nil || grok.re == nil {
 		return false
 	}
-
-	for _, groupName := range grok.re.SubexpNames() {
-		if groupName != "" {
-			return true
-		}
-	}
-
-	return false
+	return len(grok.captureFields) > 0
 }
 
 func (grok *Grok) Compile(pattern string, namedCapturesOnly bool) error {
@@ -163,42 +173,32 @@ func (grok *Grok) MatchString(text string) bool {
 
 // ParseString parses text in a form of string and returns map[string]string with values
 // not converted to types according to hints.
-// When expression is not a match nil map is returned.
+// When expression is not a match an empty map is returned.
 func (grok *Grok) ParseString(text string) (map[string]string, error) {
 	return grok.captureString(text)
 }
 
 // Parse parses text in a form of []byte and returns map[string][]byte with values
 // not converted to types according to hints.
-// When expression is not a match nil map is returned.
+// When expression is not a match an empty map is returned.
 func (grok *Grok) Parse(text []byte) (map[string][]byte, error) {
 	return grok.captureBytes(text)
 }
 
-// ParseTyped parses text and returns map[string]interface{} with values
+// ParseTyped parses text and returns map[string]any with values
 // typed according to type hints generated at compile time.
 // If hint is not found error returned is TypeNotProvided.
-// When expression is not a match nil map is returned.
-func (grok *Grok) ParseTyped(text []byte) (map[string]interface{}, error) {
-	captures, err := grok.captureTyped(text)
-	if err != nil {
-		return nil, err
-	}
-
-	captureBytes := make(map[string]interface{})
-	for k, v := range captures {
-		captureBytes[k] = v
-	}
-
-	return captureBytes, nil
+// When expression is not a match an empty map is returned.
+func (grok *Grok) ParseTyped(text []byte) (map[string]any, error) {
+	return grok.captureTypedBytes(text)
 }
 
-// ParseTypedString parses text and returns map[string]interface{} with values
+// ParseTypedString parses text and returns map[string]any with values
 // typed according to type hints generated at compile time.
 // If hint is not found error returned is TypeNotProvided.
-// When expression is not a match nil map is returned.
-func (grok *Grok) ParseTypedString(text string) (map[string]interface{}, error) {
-	return grok.ParseTyped([]byte(text))
+// When expression is not a match an empty map is returned.
+func (grok *Grok) ParseTypedString(text string) (map[string]any, error) {
+	return grok.captureTyped(text)
 }
 
 func (grok *Grok) compile(pattern string, namedCapturesOnly bool) error {
@@ -214,151 +214,238 @@ func (grok *Grok) compile(pattern string, namedCapturesOnly bool) error {
 	}
 
 	grok.re = compiledExpression
-	grok.typeHints = hints
+	grok.captureFields = buildCaptureFields(compiledExpression, hints)
 
 	return nil
 }
 
 func (grok *Grok) captureString(text string) (map[string]string, error) {
-	return captureTypeFn(grok.re, text,
-		func(v, _ string) (string, error) {
-			return v, nil
-		},
-	)
-}
+	fields := grok.captureFields
+	if len(fields) == 0 {
+		_ = grok.re.MatchString(text)
+		return make(map[string]string), nil
+	}
 
-func (grok *Grok) captureBytes(text []byte) (map[string][]byte, error) {
-	return captureTypeFn(grok.re, string(text),
-		func(v, _ string) ([]byte, error) {
-			return []byte(v), nil
-		},
-	)
-}
-
-func (grok *Grok) captureTyped(text []byte) (map[string]interface{}, error) {
-	return captureTypeFn(grok.re, string(text), grok.convertMatch)
-}
-
-func captureTypeFn[K any](re *regexp.Regexp, text string, conversionFn func(v, key string) (K, error)) (map[string]K, error) {
-	captures := make(map[string]K)
-
-	matches := re.FindStringSubmatch(text)
+	matches := grok.re.FindStringSubmatchIndex(text)
 	if len(matches) == 0 {
-		return captures, nil
+		return make(map[string]string), nil
 	}
 
-	names := re.SubexpNames()
-	if len(names) == 0 {
-		return captures, nil
-	}
-
-	for i, name := range names {
-		if len(name) == 0 {
+	captures := make(map[string]string, len(fields))
+	for _, field := range fields {
+		start, end := matches[2*field.index], matches[2*field.index+1]
+		if start < 0 || start == end {
 			continue
 		}
 
-		match := matches[i]
-		if len(match) == 0 {
-			continue
-		}
-
-		if conversionFn != nil {
-			v, err := conversionFn(string(match), name)
-			if err != nil {
-				return nil, err
-			}
-			captures[strings.ReplaceAll(name, dotSep, ".")] = v
-		}
+		captures[field.name] = text[start:end]
 	}
-
 	return captures, nil
 }
 
-func (grok *Grok) convertMatch(match, name string) (interface{}, error) {
-	hint, found := grok.typeHints[name]
-	if !found {
-		return match, nil
+func (grok *Grok) captureBytes(text []byte) (map[string][]byte, error) {
+	return extractByteCaptures(grok.re, grok.captureFields, text)
+}
+
+func (grok *Grok) captureTyped(text string) (map[string]any, error) {
+	fields := grok.captureFields
+	if len(fields) == 0 {
+		_ = grok.re.MatchString(text)
+		return make(map[string]any), nil
 	}
 
-	switch hint {
-	case "string":
+	matches := grok.re.FindStringSubmatchIndex(text)
+	if len(matches) == 0 {
+		return make(map[string]any), nil
+	}
+
+	captures := make(map[string]any, len(fields))
+	for _, field := range fields {
+		start, end := matches[2*field.index], matches[2*field.index+1]
+		if start < 0 || start == end {
+			continue
+		}
+
+		v, err := grok.convertMatch(text[start:end], field)
+		if err != nil {
+			return nil, err
+		}
+		captures[field.name] = v
+	}
+	return captures, nil
+}
+
+func (grok *Grok) captureTypedBytes(text []byte) (map[string]any, error) {
+	fields := grok.captureFields
+	if len(fields) == 0 {
+		_ = grok.re.Match(text)
+		return make(map[string]any), nil
+	}
+
+	matches := grok.re.FindSubmatchIndex(text)
+	if len(matches) == 0 {
+		return make(map[string]any), nil
+	}
+
+	captures := make(map[string]any, len(fields))
+	for _, field := range fields {
+		start, end := matches[2*field.index], matches[2*field.index+1]
+		if start < 0 || start == end {
+			continue
+		}
+
+		v, err := grok.convertMatch(string(text[start:end]), field)
+		if err != nil {
+			return nil, err
+		}
+		captures[field.name] = v
+	}
+	return captures, nil
+}
+
+func extractByteCaptures(re *regexp.Regexp, fields []captureField, text []byte) (map[string][]byte, error) {
+	if len(fields) == 0 {
+		_ = re.Match(text)
+		return make(map[string][]byte), nil
+	}
+
+	matches := re.FindSubmatchIndex(text)
+	if len(matches) == 0 {
+		return make(map[string][]byte), nil
+	}
+
+	captures := make(map[string][]byte, len(fields))
+	for _, field := range fields {
+		start, end := matches[2*field.index], matches[2*field.index+1]
+		if start < 0 || start == end {
+			continue
+		}
+		captures[field.name] = append([]byte(nil), text[start:end]...)
+	}
+	return captures, nil
+}
+
+func (grok *Grok) convertMatch(match string, field captureField) (any, error) {
+	switch field.valueType {
+	case captureValueString:
 		return match, nil
-
-	case "double":
+	case captureValueFloat:
 		return strconv.ParseFloat(match, 64)
-	case "float":
-		return strconv.ParseFloat(match, 64)
-
-	case "int":
+	case captureValueInt:
 		return strconv.Atoi(match)
-	case "long":
-		return strconv.Atoi(match)
-
-	case "bool":
-		return strconv.ParseBool(match)
-	case "boolean":
+	case captureValueBool:
 		return strconv.ParseBool(match)
 	default:
-		return nil, fmt.Errorf("invalid type for %v: %w", name, ErrTypeNotProvided)
+		return nil, fmt.Errorf("invalid type for %v: %w", field.regexpName, ErrTypeNotProvided)
+	}
+}
+
+func buildCaptureFields(re *regexp.Regexp, hints map[string]string) []captureField {
+	names := re.SubexpNames()
+	fields := make([]captureField, 0, len(names))
+	for index, regexpName := range names {
+		if regexpName == "" {
+			continue
+		}
+
+		valueType := captureValueString
+		if hint := hints[regexpName]; hint != "" {
+			valueType = captureValueTypeForHint(hint)
+		}
+		fields = append(fields, captureField{
+			index:      index,
+			regexpName: regexpName,
+			name:       strings.ReplaceAll(regexpName, dotSep, "."),
+			valueType:  valueType,
+		})
+	}
+	return fields
+}
+
+func captureValueTypeForHint(hint string) captureValueType {
+	switch hint {
+	case "", "string":
+		return captureValueString
+	case "double", "float":
+		return captureValueFloat
+	case "int", "long":
+		return captureValueInt
+	case "bool", "boolean":
+		return captureValueBool
+	default:
+		return captureValueInvalid
 	}
 }
 
 // expand processes a pattern and returns expanded regular expression, type hints and error
 func (grok *Grok) expand(pattern string, namedCapturesOnly bool) (string, map[string]string, error) {
-	hints := make(map[string]string)
+	var hints map[string]string
 	expandedPattern := pattern
 
 	// recursion break is guarding against cyclic reference in pattern definitions
 	// as this is performed only once at compile time more clever optimization (e.g detecting cycles in graph) is TBD
 	for recursionBreak := 1000; recursionBreak > 0; recursionBreak-- {
-		subMatches := reusePattern.FindAllStringSubmatch(expandedPattern, -1)
-		if len(subMatches) == 0 {
+		matches := reusePattern.FindAllStringSubmatchIndex(expandedPattern, -1)
+		if len(matches) == 0 {
 			// nothing to expand anymore
 			break
 		}
 
-		for _, nameSubmatch := range subMatches {
+		var b strings.Builder
+		b.Grow(len(expandedPattern))
+		var last int
+
+		for _, match := range matches {
 			// grok can be specified in either of these forms:
 			// %{SYNTAX} - e.g {NUMBER}
 			// %{SYNTAX:ID} - e.g {NUMBER:MY_AGE}
 			// %{SYNTAX:ID:TYPE} - e.g {NUMBER:MY_AGE:INT}
 
-			// nameSubmatch is equal to [["%{NAME:ID:TYPe}" "NAME:ID:TYPe"]]
-			// we need only inner part
-			nameParts := strings.Split(nameSubmatch[1], ":")
-
-			grokId := nameParts[0]
-			var targetId string
-			if len(nameParts) > 1 {
-				targetId = strings.ReplaceAll(nameParts[1], ".", dotSep)
-			} else {
-				targetId = nameParts[0]
-			}
-			// compile hints for used patterns
-			if len(nameParts) == 3 {
-				hints[targetId] = nameParts[2]
-			}
+			// match[2]:match[3] is the inner "SYNTAX:ID:TYPE" part.
+			grokId, targetId, typeHint, hasTarget, hasType := parseGrokName(expandedPattern[match[2]:match[3]])
 
 			knownPattern, found := grok.lookupPattern(grokId)
 			if !found {
 				return "", nil, fmt.Errorf("pattern definition %q unknown: %w", grokId, ErrParseFailure)
 			}
 
-			var replacementPattern string
-			if namedCapturesOnly && len(nameParts) == 1 {
-				// this has no semantic (pattern:foo) so we don't need to capture
-				replacementPattern = "(" + knownPattern + ")"
-
-			} else {
-				replacementPattern = "(?P<" + targetId + ">" + knownPattern + ")"
+			if hasType {
+				if hints == nil {
+					hints = make(map[string]string)
+				}
+				hints[targetId] = typeHint
 			}
 
-			// expand pattern with definition
-			expandedPattern = strings.ReplaceAll(expandedPattern, nameSubmatch[0], replacementPattern)
+			b.WriteString(expandedPattern[last:match[0]])
+			if namedCapturesOnly && !hasTarget {
+				// this has no semantic (pattern:foo) so we don't need to capture
+				b.WriteByte('(')
+				b.WriteString(knownPattern)
+				b.WriteByte(')')
+			} else {
+				b.WriteString("(?P<")
+				b.WriteString(targetId)
+				b.WriteByte('>')
+				b.WriteString(knownPattern)
+				b.WriteByte(')')
+			}
+			last = match[1]
 		}
+		b.WriteString(expandedPattern[last:])
+		expandedPattern = b.String()
 	}
 
 	return expandedPattern, hints, nil
+}
+
+func parseGrokName(name string) (grokId, targetId, typeHint string, hasTarget, hasType bool) {
+	grokId, rest, hasTarget := strings.Cut(name, ":")
+	if !hasTarget {
+		return grokId, grokId, "", false, false
+	}
+
+	target, typeHint, hasType := strings.Cut(rest, ":")
+	return grokId, strings.ReplaceAll(target, ".", dotSep), typeHint, true, hasType
 }
 
 func (grok *Grok) lookupPattern(grokId string) (string, bool) {
@@ -373,5 +460,4 @@ func (grok *Grok) lookupPattern(grokId string) (string, bool) {
 	}
 
 	return "", false
-
 }

--- a/grok.go
+++ b/grok.go
@@ -222,7 +222,6 @@ func (grok *Grok) compile(pattern string, namedCapturesOnly bool) error {
 func (grok *Grok) captureString(text string) (map[string]string, error) {
 	fields := grok.captureFields
 	if len(fields) == 0 {
-		_ = grok.re.MatchString(text)
 		return make(map[string]string), nil
 	}
 
@@ -250,7 +249,6 @@ func (grok *Grok) captureBytes(text []byte) (map[string][]byte, error) {
 func (grok *Grok) captureTyped(text string) (map[string]any, error) {
 	fields := grok.captureFields
 	if len(fields) == 0 {
-		_ = grok.re.MatchString(text)
 		return make(map[string]any), nil
 	}
 
@@ -278,7 +276,6 @@ func (grok *Grok) captureTyped(text string) (map[string]any, error) {
 func (grok *Grok) captureTypedBytes(text []byte) (map[string]any, error) {
 	fields := grok.captureFields
 	if len(fields) == 0 {
-		_ = grok.re.Match(text)
 		return make(map[string]any), nil
 	}
 
@@ -305,7 +302,6 @@ func (grok *Grok) captureTypedBytes(text []byte) (map[string]any, error) {
 
 func extractByteCaptures(re *regexp.Regexp, fields []captureField, text []byte) (map[string][]byte, error) {
 	if len(fields) == 0 {
-		_ = re.Match(text)
 		return make(map[string][]byte), nil
 	}
 
@@ -314,13 +310,24 @@ func extractByteCaptures(re *regexp.Regexp, fields []captureField, text []byte) 
 		return make(map[string][]byte), nil
 	}
 
+	var totalBytes int
+	for _, field := range fields {
+		start, end := matches[2*field.index], matches[2*field.index+1]
+		if start >= 0 && start != end {
+			totalBytes += end - start
+		}
+	}
+
+	buf := make([]byte, 0, totalBytes)
 	captures := make(map[string][]byte, len(fields))
 	for _, field := range fields {
 		start, end := matches[2*field.index], matches[2*field.index+1]
 		if start < 0 || start == end {
 			continue
 		}
-		captures[field.name] = append([]byte(nil), text[start:end]...)
+		offset := len(buf)
+		buf = append(buf, text[start:end]...)
+		captures[field.name] = buf[offset:len(buf):len(buf)]
 	}
 	return captures, nil
 }

--- a/grok.go
+++ b/grok.go
@@ -425,8 +425,9 @@ func (grok *Grok) expand(pattern string, namedCapturesOnly bool) (string, map[st
 
 			b.WriteString(expandedPattern[last:match[0]])
 			if namedCapturesOnly && !hasTarget {
-				// this has no semantic (pattern:foo) so we don't need to capture
-				b.WriteByte('(')
+				// this has no semantic (pattern:foo) so we don't need to capture;
+				// a non-capturing group keeps the regexp engine from tracking it
+				b.WriteString("(?:")
 				b.WriteString(knownPattern)
 				b.WriteByte(')')
 			} else {

--- a/grok_bench_test.go
+++ b/grok_bench_test.go
@@ -1,0 +1,302 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package grok_test
+
+import (
+	"testing"
+
+	"github.com/elastic/go-grok"
+	"github.com/elastic/go-grok/patterns"
+)
+
+const (
+	benchApachePattern = `%{IPORHOST:clientip} %{USER:ident} %{USER:auth} \[%{HTTPDATE:timestamp}\] "(?:%{WORD:verb} %{NOTSPACE:request}(?: HTTP/%{NUMBER:httpversion})?|%{DATA:rawrequest})" %{NUMBER:response} (?:%{NUMBER:bytes}|-)`
+	benchApacheInput   = `127.0.0.1 - - [23/Apr/2014:22:58:32 +0200] "GET /index.php HTTP/1.1" 404 207`
+	benchFastNoMatch   = `!`
+	benchLateNoMatch   = `127.0.0.1 - - [23/Apr/2014:22:58:32 +0200] "GET /index.php HTTP/1.1" 404 nope`
+
+	benchNestedPattern = `%{NGINX_HOST} %{USERNAME} - %{EMAILADDRESS}`
+	benchNestedInput   = `127.0.0.1:1234 grok123 - grok123@elastic.co`
+
+	benchHTTPDPattern = `%{HTTPD_COMBINEDLOG}`
+	benchHTTPDInput   = `127.0.0.1 user username [26/Jun/2024:12:34:56 -0700] "GET /index.html HTTP/1.1" 200 1234 "referrer" "Mozilla/5.0"`
+)
+
+var benchNestedPatterns = map[string]string{
+	"NGINX_HOST":         `(?:%{IP:destination.ip}|%{NGINX_NOTSEPARATOR:destination.domain})(:%{NUMBER:destination.port:int})?`,
+	"NGINX_NOTSEPARATOR": `"[^\t ,:]+"`,
+}
+
+func BenchmarkGrokCompile(b *testing.B) {
+	for _, tc := range []struct {
+		name     string
+		pattern  string
+		patterns map[string]string
+	}{
+		{name: "simple", pattern: `%{WORD:word}`},
+		{name: "apache", pattern: benchApachePattern},
+		{name: "nested", pattern: benchNestedPattern, patterns: benchNestedPatterns},
+		{name: "httpd", pattern: benchHTTPDPattern, patterns: patterns.Httpd},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			g := grok.New()
+			if tc.patterns != nil {
+				if err := g.AddPatterns(tc.patterns); err != nil {
+					b.Fatal(err)
+				}
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for n := 0; n < b.N; n++ {
+				if err := g.Compile(tc.pattern, true); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkGrokMatchString(b *testing.B) {
+	g := newCompiledBenchGrok(b, benchApachePattern, nil, true)
+
+	for _, tc := range []struct {
+		name string
+		text string
+	}{
+		{name: "match", text: benchApacheInput},
+		{name: "no_match_fast", text: benchFastNoMatch},
+		{name: "no_match_late", text: benchLateNoMatch},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for n := 0; n < b.N; n++ {
+				_ = g.MatchString(tc.text)
+			}
+		})
+	}
+}
+
+func BenchmarkGrokMatchBytes(b *testing.B) {
+	g := newCompiledBenchGrok(b, benchApachePattern, nil, true)
+
+	for _, tc := range []struct {
+		name string
+		text string
+	}{
+		{name: "match", text: benchApacheInput},
+		{name: "no_match_fast", text: benchFastNoMatch},
+		{name: "no_match_late", text: benchLateNoMatch},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			text := []byte(tc.text)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for n := 0; n < b.N; n++ {
+				_ = g.Match(text)
+			}
+		})
+	}
+}
+
+func BenchmarkGrokParseString(b *testing.B) {
+	for _, namedCapturesOnly := range []bool{true, false} {
+		name := "named_captures"
+		if !namedCapturesOnly {
+			name = "all_captures"
+		}
+
+		b.Run(name, func(b *testing.B) {
+			g := newCompiledBenchGrok(b, benchApachePattern, nil, namedCapturesOnly)
+			benchmarkParseStringCases(b, g)
+		})
+	}
+}
+
+func BenchmarkGrokParseBytes(b *testing.B) {
+	g := newCompiledBenchGrok(b, benchApachePattern, nil, true)
+
+	for _, tc := range []struct {
+		name string
+		text string
+	}{
+		{name: "match", text: benchApacheInput},
+		{name: "no_match_fast", text: benchFastNoMatch},
+		{name: "no_match_late", text: benchLateNoMatch},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			text := []byte(tc.text)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for n := 0; n < b.N; n++ {
+				if _, err := g.Parse(text); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkGrokParseTypedString(b *testing.B) {
+	g := newCompiledBenchGrok(b, benchNestedPattern, benchNestedPatterns, true)
+	benchmarkParseTypedStringCases(b, g)
+}
+
+func BenchmarkGrokParseTypedBytes(b *testing.B) {
+	g := newCompiledBenchGrok(b, benchNestedPattern, benchNestedPatterns, true)
+
+	for _, tc := range []struct {
+		name string
+		text string
+	}{
+		{name: "match", text: benchNestedInput},
+		{name: "no_match_fast", text: benchFastNoMatch},
+		{name: "no_match_late", text: `127.0.0.1:1234 grok123 - not-an-email`},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			text := []byte(tc.text)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for n := 0; n < b.N; n++ {
+				if _, err := g.ParseTyped(text); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkGrokParseStringHTTPD(b *testing.B) {
+	g := newCompiledBenchGrok(b, benchHTTPDPattern, patterns.Httpd, true)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		if _, err := g.ParseString(benchHTTPDInput); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkGrokParseNoCapture(b *testing.B) {
+	g := newCompiledBenchGrok(b, `foo`, nil, true)
+
+	for _, tc := range []struct {
+		name string
+		text string
+	}{
+		{name: "match", text: "food"},
+		{name: "no_match", text: "bar"},
+	} {
+		text := tc.text
+		textBytes := []byte(text)
+		for _, parser := range []struct {
+			name  string
+			parse func() error
+		}{
+			{"string", func() error {
+				_, err := g.ParseString(text)
+				return err
+			}},
+			{"bytes", func() error {
+				_, err := g.Parse(textBytes)
+				return err
+			}},
+			{"typed_string", func() error {
+				_, err := g.ParseTypedString(text)
+				return err
+			}},
+			{"typed_bytes", func() error {
+				_, err := g.ParseTyped(textBytes)
+				return err
+			}},
+		} {
+			parser := parser
+			b.Run(tc.name+"/"+parser.name, func(b *testing.B) {
+				b.ReportAllocs()
+				b.ResetTimer()
+				for n := 0; n < b.N; n++ {
+					if err := parser.parse(); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		}
+	}
+}
+
+func benchmarkParseStringCases(b *testing.B, g *grok.Grok) {
+	for _, tc := range []struct {
+		name string
+		text string
+	}{
+		{name: "match", text: benchApacheInput},
+		{name: "no_match_fast", text: benchFastNoMatch},
+		{name: "no_match_late", text: benchLateNoMatch},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for n := 0; n < b.N; n++ {
+				if _, err := g.ParseString(tc.text); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func benchmarkParseTypedStringCases(b *testing.B, g *grok.Grok) {
+	for _, tc := range []struct {
+		name string
+		text string
+	}{
+		{name: "match", text: benchNestedInput},
+		{name: "no_match_fast", text: benchFastNoMatch},
+		{name: "no_match_late", text: `127.0.0.1:1234 grok123 - not-an-email`},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for n := 0; n < b.N; n++ {
+				if _, err := g.ParseTypedString(tc.text); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func newCompiledBenchGrok(b testing.TB, pattern string, patternDefinitions map[string]string, namedCapturesOnly bool) *grok.Grok {
+	b.Helper()
+
+	g := grok.New()
+	if patternDefinitions != nil {
+		if err := g.AddPatterns(patternDefinitions); err != nil {
+			b.Fatal(err)
+		}
+	}
+	if err := g.Compile(pattern, namedCapturesOnly); err != nil {
+		b.Fatal(err)
+	}
+	return g
+}

--- a/grok_bench_test.go
+++ b/grok_bench_test.go
@@ -33,6 +33,9 @@ const (
 	benchNestedPattern = `%{NGINX_HOST} %{USERNAME} - %{EMAILADDRESS}`
 	benchNestedInput   = `127.0.0.1:1234 grok123 - grok123@elastic.co`
 
+	benchAnchoredPattern = `%{PATTERN}`
+	benchAnchoredInput   = `abcd`
+
 	benchHTTPDPattern = `%{HTTPD_COMBINEDLOG}`
 	benchHTTPDInput   = `127.0.0.1 user username [26/Jun/2024:12:34:56 -0700] "GET /index.html HTTP/1.1" 200 1234 "referrer" "Mozilla/5.0"`
 )
@@ -40,6 +43,14 @@ const (
 var benchNestedPatterns = map[string]string{
 	"NGINX_HOST":         `(?:%{IP:destination.ip}|%{NGINX_NOTSEPARATOR:destination.domain})(:%{NUMBER:destination.port:int})?`,
 	"NGINX_NOTSEPARATOR": `"[^\t ,:]+"`,
+}
+
+var benchAnchoredPatterns = map[string]string{
+	"PATTERN": `^abcd$`,
+}
+
+var benchStartAnchoredPatterns = map[string]string{
+	"PATTERN": `^bcd'`,
 }
 
 func BenchmarkGrokCompile(b *testing.B) {
@@ -51,20 +62,42 @@ func BenchmarkGrokCompile(b *testing.B) {
 		{name: "simple", pattern: `%{WORD:word}`},
 		{name: "apache", pattern: benchApachePattern},
 		{name: "nested", pattern: benchNestedPattern, patterns: benchNestedPatterns},
+		{name: "anchored_full", pattern: benchAnchoredPattern, patterns: benchAnchoredPatterns},
+		{name: "anchored_start", pattern: benchAnchoredPattern, patterns: benchStartAnchoredPatterns},
 		{name: "httpd", pattern: benchHTTPDPattern, patterns: patterns.Httpd},
 	} {
 		b.Run(tc.name, func(b *testing.B) {
-			g := grok.New()
-			if tc.patterns != nil {
-				if err := g.AddPatterns(tc.patterns); err != nil {
+			b.ReportAllocs()
+			for n := 0; n < b.N; n++ {
+				g := grok.New()
+				if tc.patterns != nil {
+					if err := g.AddPatterns(tc.patterns); err != nil {
+						b.Fatal(err)
+					}
+				}
+				if err := g.Compile(tc.pattern, true); err != nil {
 					b.Fatal(err)
 				}
 			}
+		})
+	}
+}
+
+func BenchmarkGrokRecompileAnchored(b *testing.B) {
+	for _, tc := range []struct {
+		name     string
+		patterns map[string]string
+	}{
+		{name: "full", patterns: benchAnchoredPatterns},
+		{name: "start", patterns: benchStartAnchoredPatterns},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			g := newCompiledBenchGrok(b, benchAnchoredPattern, tc.patterns, true)
 
 			b.ReportAllocs()
 			b.ResetTimer()
 			for n := 0; n < b.N; n++ {
-				if err := g.Compile(tc.pattern, true); err != nil {
+				if err := g.Compile(benchAnchoredPattern, true); err != nil {
 					b.Fatal(err)
 				}
 			}
@@ -84,6 +117,28 @@ func BenchmarkGrokMatchString(b *testing.B) {
 		{name: "no_match_late", text: benchLateNoMatch},
 	} {
 		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for n := 0; n < b.N; n++ {
+				_ = g.MatchString(tc.text)
+			}
+		})
+	}
+}
+
+func BenchmarkGrokMatchStringAnchored(b *testing.B) {
+	for _, tc := range []struct {
+		name     string
+		patterns map[string]string
+		text     string
+	}{
+		{name: "full/match", patterns: benchAnchoredPatterns, text: benchAnchoredInput},
+		{name: "full/no_match", patterns: benchAnchoredPatterns, text: "abcde"},
+		{name: "start/no_match", patterns: benchStartAnchoredPatterns, text: "abcdef"},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			g := newCompiledBenchGrok(b, benchAnchoredPattern, tc.patterns, true)
+
 			b.ReportAllocs()
 			b.ResetTimer()
 			for n := 0; n < b.N; n++ {

--- a/grok_semantics_test.go
+++ b/grok_semantics_test.go
@@ -1,0 +1,231 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package grok_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/go-grok"
+)
+
+func TestParseNoMatchReturnsEmptyMap(t *testing.T) {
+	g := grok.New()
+	require.NoError(t, g.Compile(`%{WORD:word} %{INT:number:int}`, true))
+
+	for _, tt := range []struct {
+		name  string
+		check func(*testing.T)
+	}{
+		{"ParseString", func(t *testing.T) {
+			captures, err := g.ParseString("1234")
+			require.NoError(t, err)
+			require.NotNil(t, captures)
+			require.Empty(t, captures)
+		}},
+		{"Parse", func(t *testing.T) {
+			captures, err := g.Parse([]byte("1234"))
+			require.NoError(t, err)
+			require.NotNil(t, captures)
+			require.Empty(t, captures)
+		}},
+		{"ParseTypedString", func(t *testing.T) {
+			captures, err := g.ParseTypedString("1234")
+			require.NoError(t, err)
+			require.NotNil(t, captures)
+			require.Empty(t, captures)
+		}},
+		{"ParseTyped", func(t *testing.T) {
+			captures, err := g.ParseTyped([]byte("1234"))
+			require.NoError(t, err)
+			require.NotNil(t, captures)
+			require.Empty(t, captures)
+		}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.check(t)
+		})
+	}
+}
+
+func TestByteAndStringAPIsHaveMatchingResults(t *testing.T) {
+	g := grok.New()
+	require.NoError(t, g.Compile(`%{WORD:word} %{INT:number:int}`, true))
+
+	text := "hello 42"
+
+	require.Equal(t, g.MatchString(text), g.Match([]byte(text)))
+
+	stringCaptures, err := g.ParseString(text)
+	require.NoError(t, err)
+
+	byteCaptures, err := g.Parse([]byte(text))
+	require.NoError(t, err)
+	require.Len(t, byteCaptures, len(stringCaptures))
+	for name, value := range stringCaptures {
+		require.Equal(t, value, string(byteCaptures[name]))
+	}
+
+	typedStringCaptures, err := g.ParseTypedString(text)
+	require.NoError(t, err)
+
+	typedByteCaptures, err := g.ParseTyped([]byte(text))
+	require.NoError(t, err)
+	require.Equal(t, typedStringCaptures, typedByteCaptures)
+}
+
+func TestParseByteCapturesDoNotAliasInput(t *testing.T) {
+	g := grok.New()
+	require.NoError(t, g.Compile(`%{WORD:word} %{INT:number}`, true))
+
+	text := []byte("hello 42")
+	captures, err := g.Parse(text)
+	require.NoError(t, err)
+
+	text[0] = 'j'
+	text[len(text)-1] = '0'
+
+	require.Equal(t, []byte("hello"), captures["word"])
+	require.Equal(t, []byte("42"), captures["number"])
+}
+
+func TestParseWithoutCaptureGroupsReturnsEmptyMap(t *testing.T) {
+	g := grok.New()
+	require.NoError(t, g.Compile(`foo`, true))
+
+	for _, tt := range []struct {
+		name  string
+		check func(*testing.T, string)
+	}{
+		{"ParseString", func(t *testing.T, text string) {
+			captures, err := g.ParseString(text)
+			require.NoError(t, err)
+			require.NotNil(t, captures)
+			require.Empty(t, captures)
+		}},
+		{"Parse", func(t *testing.T, text string) {
+			captures, err := g.Parse([]byte(text))
+			require.NoError(t, err)
+			require.NotNil(t, captures)
+			require.Empty(t, captures)
+		}},
+		{"ParseTypedString", func(t *testing.T, text string) {
+			captures, err := g.ParseTypedString(text)
+			require.NoError(t, err)
+			require.NotNil(t, captures)
+			require.Empty(t, captures)
+		}},
+		{"ParseTyped", func(t *testing.T, text string) {
+			captures, err := g.ParseTyped([]byte(text))
+			require.NoError(t, err)
+			require.NotNil(t, captures)
+			require.Empty(t, captures)
+		}},
+	} {
+		t.Run(tt.name+"/match", func(t *testing.T) {
+			tt.check(t, "food")
+		})
+
+		t.Run(tt.name+"/no_match", func(t *testing.T) {
+			tt.check(t, "bar")
+		})
+	}
+}
+
+func TestParseTypedInvalidTypeHintReturnsTypeError(t *testing.T) {
+	g := grok.New()
+	require.NoError(t, g.Compile(`%{WORD:word:nope}`, true))
+
+	captures, err := g.ParseTypedString("hello")
+	require.ErrorIs(t, err, grok.ErrTypeNotProvided)
+	require.Nil(t, captures)
+}
+
+func TestCompileExpansionSemantics(t *testing.T) {
+	tests := []struct {
+		name              string
+		patterns          map[string]string
+		pattern           string
+		text              string
+		namedCapturesOnly bool
+		want              map[string]string
+	}{
+		{
+			name:              "repeated tokens keep distinct targets",
+			pattern:           `%{WORD:first} %{WORD:second}`,
+			text:              "hello world",
+			namedCapturesOnly: true,
+			want: map[string]string{
+				"first":  "hello",
+				"second": "world",
+			},
+		},
+		{
+			name: "nested expansion keeps inner captures",
+			patterns: map[string]string{
+				"OUTER": `%{INNER} %{WORD:second}`,
+				"INNER": `%{WORD:first}`,
+			},
+			pattern:           `%{OUTER}`,
+			text:              "hello world",
+			namedCapturesOnly: true,
+			want: map[string]string{
+				"first":  "hello",
+				"second": "world",
+			},
+		},
+		{
+			name:              "dotted fields are restored in output names",
+			pattern:           `%{WORD:destination.port}`,
+			text:              "hello",
+			namedCapturesOnly: true,
+			want: map[string]string{
+				"destination.port": "hello",
+			},
+		},
+		{
+			name:              "unnamed captures are skipped when named only",
+			pattern:           `%{WORD}`,
+			text:              "hello",
+			namedCapturesOnly: true,
+			want:              map[string]string{},
+		},
+		{
+			name:              "unnamed captures use pattern name when allowed",
+			pattern:           `%{WORD}`,
+			text:              "hello",
+			namedCapturesOnly: false,
+			want: map[string]string{
+				"WORD": "hello",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := grok.New()
+			require.NoError(t, g.AddPatterns(tt.patterns))
+			require.NoError(t, g.Compile(tt.pattern, tt.namedCapturesOnly))
+
+			got, err := g.ParseString(tt.text)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/grok_semantics_test.go
+++ b/grok_semantics_test.go
@@ -166,11 +166,46 @@ func TestParseWithoutCaptureGroupsReturnsEmptyMap(t *testing.T) {
 
 func TestParseTypedInvalidTypeHintReturnsTypeError(t *testing.T) {
 	g := grok.New()
-	require.NoError(t, g.Compile(`%{WORD:word:nope}`, true))
+	require.NoError(t, g.Compile(`%{WORD:destination.port:nope}`, true))
 
-	captures, err := g.ParseTypedString("hello")
-	require.ErrorIs(t, err, grok.ErrTypeNotProvided)
-	require.Nil(t, captures)
+	for _, tt := range []struct {
+		name  string
+		parse func() (map[string]any, error)
+	}{
+		{"ParseTypedString", func() (map[string]any, error) {
+			return g.ParseTypedString("hello")
+		}},
+		{"ParseTyped", func() (map[string]any, error) {
+			return g.ParseTyped([]byte("hello"))
+		}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			captures, err := tt.parse()
+			require.EqualError(t, err, "invalid type for destination___port: type not specified")
+			require.ErrorIs(t, err, grok.ErrTypeNotProvided)
+			require.Nil(t, captures)
+		})
+	}
+}
+
+func TestRecompileRefreshesRegexpAndCaptureMetadata(t *testing.T) {
+	g := grok.NewWithoutDefaultPatterns()
+	require.NoError(t, g.AddPattern("VALUE", `\d+`))
+	require.NoError(t, g.Compile(`%{VALUE:value:string}`, true))
+
+	captures, err := g.ParseTypedString("42")
+	require.NoError(t, err)
+	require.Equal(t, map[string]any{"value": "42"}, captures)
+
+	require.NoError(t, g.Compile(`%{VALUE:value:int}`, true))
+	captures, err = g.ParseTypedString("42")
+	require.NoError(t, err)
+	require.Equal(t, map[string]any{"value": 42}, captures)
+
+	require.NoError(t, g.AddPattern("VALUE", `[a-z]+`))
+	require.NoError(t, g.Compile(`%{VALUE:value:int}`, true))
+	require.False(t, g.MatchString("42"))
+	require.True(t, g.MatchString("hello"))
 }
 
 func TestCompileExpansionSemantics(t *testing.T) {

--- a/grok_semantics_test.go
+++ b/grok_semantics_test.go
@@ -105,6 +105,22 @@ func TestParseByteCapturesDoNotAliasInput(t *testing.T) {
 	require.Equal(t, []byte("42"), captures["number"])
 }
 
+func TestParseByteCapturesAreIndependent(t *testing.T) {
+	g := grok.New()
+	require.NoError(t, g.Compile(`%{WORD:first} %{WORD:second}`, true))
+
+	captures, err := g.Parse([]byte("hello world"))
+	require.NoError(t, err)
+
+	captures["first"][0] = 'j'
+	require.Equal(t, []byte("jello"), captures["first"])
+	require.Equal(t, []byte("world"), captures["second"])
+
+	extended := append(captures["first"], '!')
+	require.Equal(t, []byte("jello!"), extended)
+	require.Equal(t, []byte("world"), captures["second"])
+}
+
 func TestParseWithoutCaptureGroupsReturnsEmptyMap(t *testing.T) {
 	g := grok.New()
 	require.NoError(t, g.Compile(`foo`, true))

--- a/grok_test.go
+++ b/grok_test.go
@@ -213,13 +213,12 @@ func TestParse(t *testing.T) {
 
 func TestParseWithDefaultPatterns(t *testing.T) {
 	testCases := []struct {
-		Name                 string
-		Patterns             map[string]string
-		Pattern              string
-		Text                 string
-		ExpectedMatches      map[string]string
-		ExpectedTypedMatches map[string]interface{}
-		NamedCapturesOnly    bool
+		Name              string
+		Patterns          map[string]string
+		Pattern           string
+		Text              string
+		ExpectedMatches   map[string]string
+		NamedCapturesOnly bool
 	}{
 		{
 			"hostname defined by nested patterns",
@@ -233,7 +232,6 @@ func TestParseWithDefaultPatterns(t *testing.T) {
 				"destination.ip":   "127.0.0.1",
 				"destination.port": "1234",
 			},
-			nil,
 			true,
 		},
 
@@ -252,7 +250,6 @@ func TestParseWithDefaultPatterns(t *testing.T) {
 				"NGINX_HOST":       "127.0.0.1:1234",
 				"IPV4":             "127.0.0.1",
 			},
-			nil,
 			false,
 		},
 	}
@@ -284,7 +281,7 @@ func TestTypedParseWithDefaultPatterns(t *testing.T) {
 		Patterns             map[string]string
 		Pattern              string
 		Text                 string
-		ExpectedTypedMatches map[string]interface{}
+		ExpectedTypedMatches map[string]any
 		NamedCapturesOnly    bool
 	}{
 		{
@@ -295,7 +292,7 @@ func TestTypedParseWithDefaultPatterns(t *testing.T) {
 			},
 			"%{NGINX_HOST}",
 			"127.0.0.1:1234",
-			map[string]interface{}{
+			map[string]any{
 				"destination.ip":   "127.0.0.1",
 				"destination.port": "1234",
 				"BASE10NUM":        "1234",
@@ -314,7 +311,7 @@ func TestTypedParseWithDefaultPatterns(t *testing.T) {
 			},
 			"%{NGINX_HOST} %{BOOL:destination.boolean:boolean}",
 			"127.0.0.1:1234 true",
-			map[string]interface{}{
+			map[string]any{
 				"destination.ip":      "127.0.0.1",
 				"destination.port":    1234,
 				"destination.boolean": true,


### PR DESCRIPTION
Reduces allocation pressure in the grok parse hot path by moving capture extraction to precomputed metadata and submatch indexes. This avoids repeated `SubexpNames` work, full-input byte/string round trips on byte APIs, and per-capture type-hint string switching.

This keeps behavior unchanged: no-match parses still return non-nil empty maps, optional empty captures are still skipped, typed values keep the same dynamic types, and `Parse([]byte)` still returns independent byte slices rather than aliases into caller-owned input.

Benchmark comparison against `origin/main`, using the same focused bench file. Match-only workloads stay effectively flat; the main win is lower allocation pressure in parse paths.

| Benchmark | sec/op | B/op | allocs/op |
|---|---:|---:|---:|
| expanded suite geomean | -34.09% | -32.58% | -38.09% |
| `GrokParseString/all_captures/match` | -2.69% | -47.27% | -44.44% |
| `GrokParseBytes/match` | -12.72% | -51.65% | -64.71% |
| `GrokParseTypedString/match` | -12.26% | -54.38% | -54.55% |
| `GrokParseTypedBytes/match` | -11.46% | -53.62% | -36.36% |
| `GrokParseStringHTTPD` | -19.67% | -59.48% | -70.59% |
| `GrokParseNoCapture/match/typed_string` | -81.75% | -58.97% | -75.00% |

### Repeated compilation

`Compile` must still expand the Grok pattern because pattern definitions and type hints may have changed. After expansion, if the resulting regular expression matches the currently compiled expression, it now reuses the existing `regexp.Regexp` instead of compiling it again.

Capture metadata is rebuilt even when the regexp is reused, so changed type hints remain correct. Changed expanded expressions still take the normal cold-compilation path.

| Benchmark | Main | Current | Delta |
|---|---:|---:|---:|
| Recompile `^abcd$` | 1.464 µs, 2.705 KiB, 26 allocs | 240.2 ns, 48 B, 2 allocs | -83.58% time, -98.27% B/op |
| Recompile `^bcd'` | 1.399 µs, 2.672 KiB, 25 allocs | 240.2 ns, 48 B, 2 allocs | -82.83% time, -98.25% B/op |
| geomean | | | -83.21% time, -98.26% B/op, -92.16% allocs |

Cold compilation also benefits from iterative pattern expansion and smaller capture metadata. Across the original simple, Apache, nested, and HTTPD compile cases, the geomean changes by `-3.33% sec/op`, `-6.45% B/op`, and `-4.58% allocs/op`.

One important caveat is that the anchored cold-compile cases are now 11–13% slower and allocate 11–12 additional objects because Go builds its faster one-pass matcher. That cost is paid once; matching those expressions is 29-39% faster afterward, so I still generally see this as a win given the overall profile.

Also:

- Adds focused benchmarks for compile, match-only, string parse, byte parse, typed parse, no-capture parse, and HTTPD parsing.
- Adds semantic tests for expansion behavior, no-match maps, byte capture ownership, byte/string API parity & invalid type-hint errors.

NOTE: Most of the changes are benchmark / test additions, the actual changes are quite contained and small.