### PR TITLE
fix: correct casing to lowercase streams (matches actual GitHub team slug)

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -9,6 +9,6 @@ metadata:
 
 spec:
   type: library
-  owner: group:Streams
+  owner: group:streams
   system: platform-ingest
   lifecycle: production


### PR DESCRIPTION
The previous PR renamed the team reference in `catalog-info.yaml` to `Streams` (capital S), but GitHub team slugs are always lowercase. The actual team is `elastic/streams`. This PR corrects the casing to `streams` — no other changes.