### PR TITLE
feat: add Nagios grok patterns

### DIFF
--- a/grok.go
+++ b/grok.go
@@ -93,6 +93,7 @@ func NewComplete(additionalPatterns ...map[string]string) (*Grok, error) {
 		patterns.Maven,
 		patterns.MCollective,
 		patterns.MongoDB,
+		patterns.Nagios,
 		patterns.PostgreSQL,
 		patterns.Rails,
 		patterns.Redis,

--- a/patterns/nagios.go
+++ b/patterns/nagios.go
@@ -1,0 +1,108 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package patterns
+
+// Nagios patterns ported from elastic/elasticsearch ecs-v1/nagios.
+var Nagios map[string]string = map[string]string{
+	"NAGIOSTIME": `\[%{NUMBER:timestamp}\]`,
+
+	"NAGIOS_TYPE_CURRENT_SERVICE_STATE": "CURRENT SERVICE STATE",
+	"NAGIOS_TYPE_CURRENT_HOST_STATE":    "CURRENT HOST STATE",
+
+	"NAGIOS_TYPE_SERVICE_NOTIFICATION": "SERVICE NOTIFICATION",
+	"NAGIOS_TYPE_HOST_NOTIFICATION":    "HOST NOTIFICATION",
+
+	"NAGIOS_TYPE_SERVICE_ALERT": "SERVICE ALERT",
+	"NAGIOS_TYPE_HOST_ALERT":    "HOST ALERT",
+
+	"NAGIOS_TYPE_SERVICE_FLAPPING_ALERT": "SERVICE FLAPPING ALERT",
+	"NAGIOS_TYPE_HOST_FLAPPING_ALERT":    "HOST FLAPPING ALERT",
+
+	"NAGIOS_TYPE_SERVICE_DOWNTIME_ALERT": "SERVICE DOWNTIME ALERT",
+	"NAGIOS_TYPE_HOST_DOWNTIME_ALERT":    "HOST DOWNTIME ALERT",
+
+	"NAGIOS_TYPE_PASSIVE_SERVICE_CHECK": "PASSIVE SERVICE CHECK",
+	"NAGIOS_TYPE_PASSIVE_HOST_CHECK":    "PASSIVE HOST CHECK",
+
+	"NAGIOS_TYPE_SERVICE_EVENT_HANDLER": "SERVICE EVENT HANDLER",
+	"NAGIOS_TYPE_HOST_EVENT_HANDLER":    "HOST EVENT HANDLER",
+
+	"NAGIOS_TYPE_EXTERNAL_COMMAND":     "EXTERNAL COMMAND",
+	"NAGIOS_TYPE_TIMEPERIOD_TRANSITION": "TIMEPERIOD TRANSITION",
+
+	"NAGIOS_EC_DISABLE_SVC_CHECK":              "DISABLE_SVC_CHECK",
+	"NAGIOS_EC_ENABLE_SVC_CHECK":               "ENABLE_SVC_CHECK",
+	"NAGIOS_EC_DISABLE_HOST_CHECK":             "DISABLE_HOST_CHECK",
+	"NAGIOS_EC_ENABLE_HOST_CHECK":              "ENABLE_HOST_CHECK",
+	"NAGIOS_EC_PROCESS_SERVICE_CHECK_RESULT":   "PROCESS_SERVICE_CHECK_RESULT",
+	"NAGIOS_EC_PROCESS_HOST_CHECK_RESULT":      "PROCESS_HOST_CHECK_RESULT",
+	"NAGIOS_EC_SCHEDULE_SERVICE_DOWNTIME":      "SCHEDULE_SERVICE_DOWNTIME",
+	"NAGIOS_EC_SCHEDULE_HOST_DOWNTIME":         "SCHEDULE_HOST_DOWNTIME",
+	"NAGIOS_EC_DISABLE_HOST_SVC_NOTIFICATIONS": "DISABLE_HOST_SVC_NOTIFICATIONS",
+	"NAGIOS_EC_ENABLE_HOST_SVC_NOTIFICATIONS":  "ENABLE_HOST_SVC_NOTIFICATIONS",
+	"NAGIOS_EC_DISABLE_HOST_NOTIFICATIONS":     "DISABLE_HOST_NOTIFICATIONS",
+	"NAGIOS_EC_ENABLE_HOST_NOTIFICATIONS":      "ENABLE_HOST_NOTIFICATIONS",
+	"NAGIOS_EC_DISABLE_SVC_NOTIFICATIONS":      "DISABLE_SVC_NOTIFICATIONS",
+	"NAGIOS_EC_ENABLE_SVC_NOTIFICATIONS":       "ENABLE_SVC_NOTIFICATIONS",
+
+	"NAGIOS_WARNING": `Warning:%{SPACE}%{GREEDYDATA:message}`,
+
+	"NAGIOS_CURRENT_SERVICE_STATE": `%{NAGIOS_TYPE_CURRENT_SERVICE_STATE:nagios.log.type}: %{DATA:host.hostname};%{DATA:service.name};%{DATA:service.state};%{DATA:nagios.log.state_type};%{INT:nagios.log.attempt:int};%{GREEDYDATA:message}`,
+	"NAGIOS_CURRENT_HOST_STATE":    `%{NAGIOS_TYPE_CURRENT_HOST_STATE:nagios.log.type}: %{DATA:host.hostname};%{DATA:service.state};%{DATA:nagios.log.state_type};%{INT:nagios.log.attempt:int};%{GREEDYDATA:message}`,
+
+	"NAGIOS_SERVICE_NOTIFICATION": `%{NAGIOS_TYPE_SERVICE_NOTIFICATION:nagios.log.type}: %{DATA:user.name};%{DATA:host.hostname};%{DATA:service.name};%{DATA:service.state};%{DATA:nagios.log.notification_command};%{GREEDYDATA:message}`,
+	"NAGIOS_HOST_NOTIFICATION":    `%{NAGIOS_TYPE_HOST_NOTIFICATION:nagios.log.type}: %{DATA:user.name};%{DATA:host.hostname};%{DATA:service.state};%{DATA:nagios.log.notification_command};%{GREEDYDATA:message}`,
+
+	"NAGIOS_SERVICE_ALERT": `%{NAGIOS_TYPE_SERVICE_ALERT:nagios.log.type}: %{DATA:host.hostname};%{DATA:service.name};%{DATA:service.state};%{DATA:nagios.log.state_type};%{INT:nagios.log.attempt:int};%{GREEDYDATA:message}`,
+	"NAGIOS_HOST_ALERT":    `%{NAGIOS_TYPE_HOST_ALERT:nagios.log.type}: %{DATA:host.hostname};%{DATA:service.state};%{DATA:nagios.log.state_type};%{INT:nagios.log.attempt:int};%{GREEDYDATA:message}`,
+
+	"NAGIOS_SERVICE_FLAPPING_ALERT": `%{NAGIOS_TYPE_SERVICE_FLAPPING_ALERT:nagios.log.type}: %{DATA:host.hostname};%{DATA:service.name};%{DATA:service.state};%{GREEDYDATA:message}`,
+	"NAGIOS_HOST_FLAPPING_ALERT":    `%{NAGIOS_TYPE_HOST_FLAPPING_ALERT:nagios.log.type}: %{DATA:host.hostname};%{DATA:service.state};%{GREEDYDATA:message}`,
+
+	"NAGIOS_SERVICE_DOWNTIME_ALERT": `%{NAGIOS_TYPE_SERVICE_DOWNTIME_ALERT:nagios.log.type}: %{DATA:host.hostname};%{DATA:service.name};%{DATA:service.state};%{GREEDYDATA:nagios.log.comment}`,
+	"NAGIOS_HOST_DOWNTIME_ALERT":    `%{NAGIOS_TYPE_HOST_DOWNTIME_ALERT:nagios.log.type}: %{DATA:host.hostname};%{DATA:service.state};%{GREEDYDATA:nagios.log.comment}`,
+
+	"NAGIOS_PASSIVE_SERVICE_CHECK": `%{NAGIOS_TYPE_PASSIVE_SERVICE_CHECK:nagios.log.type}: %{DATA:host.hostname};%{DATA:service.name};%{DATA:service.state};%{GREEDYDATA:nagios.log.comment}`,
+	"NAGIOS_PASSIVE_HOST_CHECK":    `%{NAGIOS_TYPE_PASSIVE_HOST_CHECK:nagios.log.type}: %{DATA:host.hostname};%{DATA:service.state};%{GREEDYDATA:nagios.log.comment}`,
+
+	"NAGIOS_SERVICE_EVENT_HANDLER": `%{NAGIOS_TYPE_SERVICE_EVENT_HANDLER:nagios.log.type}: %{DATA:host.hostname};%{DATA:service.name};%{DATA:service.state};%{DATA:nagios.log.state_type};%{DATA:nagios.log.event_handler_name}`,
+	"NAGIOS_HOST_EVENT_HANDLER":    `%{NAGIOS_TYPE_HOST_EVENT_HANDLER:nagios.log.type}: %{DATA:host.hostname};%{DATA:service.state};%{DATA:nagios.log.state_type};%{DATA:nagios.log.event_handler_name}`,
+
+	"NAGIOS_TIMEPERIOD_TRANSITION": `%{NAGIOS_TYPE_TIMEPERIOD_TRANSITION:nagios.log.type}: %{DATA:service.name};%{NUMBER:nagios.log.period_from:int};%{NUMBER:nagios.log.period_to:int}`,
+
+	"NAGIOS_EC_LINE_DISABLE_SVC_CHECK":  `%{NAGIOS_TYPE_EXTERNAL_COMMAND:nagios.log.type}: %{NAGIOS_EC_DISABLE_SVC_CHECK:nagios.log.command};%{DATA:host.hostname};%{DATA:service.name}`,
+	"NAGIOS_EC_LINE_DISABLE_HOST_CHECK": `%{NAGIOS_TYPE_EXTERNAL_COMMAND:nagios.log.type}: %{NAGIOS_EC_DISABLE_HOST_CHECK:nagios.log.command};%{DATA:host.hostname}`,
+
+	"NAGIOS_EC_LINE_ENABLE_SVC_CHECK":  `%{NAGIOS_TYPE_EXTERNAL_COMMAND:nagios.log.type}: %{NAGIOS_EC_ENABLE_SVC_CHECK:nagios.log.command};%{DATA:host.hostname};%{DATA:service.name}`,
+	"NAGIOS_EC_LINE_ENABLE_HOST_CHECK": `%{NAGIOS_TYPE_EXTERNAL_COMMAND:nagios.log.type}: %{NAGIOS_EC_ENABLE_HOST_CHECK:nagios.log.command};%{DATA:host.hostname}`,
+
+	"NAGIOS_EC_LINE_PROCESS_SERVICE_CHECK_RESULT": `%{NAGIOS_TYPE_EXTERNAL_COMMAND:nagios.log.type}: %{NAGIOS_EC_PROCESS_SERVICE_CHECK_RESULT:nagios.log.command};%{DATA:host.hostname};%{DATA:service.name};%{DATA:service.state};%{GREEDYDATA:nagios.log.check_result}`,
+	"NAGIOS_EC_LINE_PROCESS_HOST_CHECK_RESULT":    `%{NAGIOS_TYPE_EXTERNAL_COMMAND:nagios.log.type}: %{NAGIOS_EC_PROCESS_HOST_CHECK_RESULT:nagios.log.command};%{DATA:host.hostname};%{DATA:service.state};%{GREEDYDATA:nagios.log.check_result}`,
+
+	"NAGIOS_EC_LINE_DISABLE_HOST_SVC_NOTIFICATIONS": `%{NAGIOS_TYPE_EXTERNAL_COMMAND:nagios.log.type}: %{NAGIOS_EC_DISABLE_HOST_SVC_NOTIFICATIONS:nagios.log.command};%{GREEDYDATA:host.hostname}`,
+	"NAGIOS_EC_LINE_DISABLE_HOST_NOTIFICATIONS":     `%{NAGIOS_TYPE_EXTERNAL_COMMAND:nagios.log.type}: %{NAGIOS_EC_DISABLE_HOST_NOTIFICATIONS:nagios.log.command};%{GREEDYDATA:host.hostname}`,
+	"NAGIOS_EC_LINE_DISABLE_SVC_NOTIFICATIONS":      `%{NAGIOS_TYPE_EXTERNAL_COMMAND:nagios.log.type}: %{NAGIOS_EC_DISABLE_SVC_NOTIFICATIONS:nagios.log.command};%{DATA:host.hostname};%{GREEDYDATA:service.name}`,
+
+	"NAGIOS_EC_LINE_ENABLE_HOST_SVC_NOTIFICATIONS": `%{NAGIOS_TYPE_EXTERNAL_COMMAND:nagios.log.type}: %{NAGIOS_EC_ENABLE_HOST_SVC_NOTIFICATIONS:nagios.log.command};%{GREEDYDATA:host.hostname}`,
+	"NAGIOS_EC_LINE_ENABLE_HOST_NOTIFICATIONS":     `%{NAGIOS_TYPE_EXTERNAL_COMMAND:nagios.log.type}: %{NAGIOS_EC_ENABLE_HOST_NOTIFICATIONS:nagios.log.command};%{GREEDYDATA:host.hostname}`,
+	"NAGIOS_EC_LINE_ENABLE_SVC_NOTIFICATIONS":      `%{NAGIOS_TYPE_EXTERNAL_COMMAND:nagios.log.type}: %{NAGIOS_EC_ENABLE_SVC_NOTIFICATIONS:nagios.log.command};%{DATA:host.hostname};%{GREEDYDATA:service.name}`,
+
+	"NAGIOS_EC_LINE_SCHEDULE_HOST_DOWNTIME": `%{NAGIOS_TYPE_EXTERNAL_COMMAND:nagios.log.type}: %{NAGIOS_EC_SCHEDULE_HOST_DOWNTIME:nagios.log.command};%{DATA:host.hostname};%{NUMBER:nagios.log.start_time};%{NUMBER:nagios.log.end_time};%{NUMBER:nagios.log.fixed};%{NUMBER:nagios.log.trigger_id};%{NUMBER:nagios.log.duration:int};%{DATA:user.name};%{DATA:nagios.log.comment}`,
+
+	"NAGIOSLOGLINE": `%{NAGIOSTIME} (?:%{NAGIOS_WARNING}|%{NAGIOS_CURRENT_SERVICE_STATE}|%{NAGIOS_CURRENT_HOST_STATE}|%{NAGIOS_SERVICE_NOTIFICATION}|%{NAGIOS_HOST_NOTIFICATION}|%{NAGIOS_SERVICE_ALERT}|%{NAGIOS_HOST_ALERT}|%{NAGIOS_SERVICE_FLAPPING_ALERT}|%{NAGIOS_HOST_FLAPPING_ALERT}|%{NAGIOS_SERVICE_DOWNTIME_ALERT}|%{NAGIOS_HOST_DOWNTIME_ALERT}|%{NAGIOS_PASSIVE_SERVICE_CHECK}|%{NAGIOS_PASSIVE_HOST_CHECK}|%{NAGIOS_SERVICE_EVENT_HANDLER}|%{NAGIOS_HOST_EVENT_HANDLER}|%{NAGIOS_TIMEPERIOD_TRANSITION}|%{NAGIOS_EC_LINE_DISABLE_SVC_CHECK}|%{NAGIOS_EC_LINE_ENABLE_SVC_CHECK}|%{NAGIOS_EC_LINE_DISABLE_HOST_CHECK}|%{NAGIOS_EC_LINE_ENABLE_HOST_CHECK}|%{NAGIOS_EC_LINE_PROCESS_HOST_CHECK_RESULT}|%{NAGIOS_EC_LINE_PROCESS_SERVICE_CHECK_RESULT}|%{NAGIOS_EC_LINE_SCHEDULE_HOST_DOWNTIME}|%{NAGIOS_EC_LINE_DISABLE_HOST_SVC_NOTIFICATIONS}|%{NAGIOS_EC_LINE_ENABLE_HOST_SVC_NOTIFICATIONS}|%{NAGIOS_EC_LINE_DISABLE_HOST_NOTIFICATIONS}|%{NAGIOS_EC_LINE_ENABLE_HOST_NOTIFICATIONS}|%{NAGIOS_EC_LINE_DISABLE_SVC_NOTIFICATIONS}|%{NAGIOS_EC_LINE_ENABLE_SVC_NOTIFICATIONS})`,
+}

--- a/patterns_test/nagios_test.go
+++ b/patterns_test/nagios_test.go
@@ -1,0 +1,124 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package patterns_test
+
+import (
+	"testing"
+
+	"github.com/elastic/go-grok"
+	"github.com/elastic/go-grok/patterns"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseWithPatterns_Nagios(t *testing.T) {
+	testCases := []struct {
+		Name            string
+		Pattern         string
+		Text            string
+		ExpectedMatches map[string]string
+	}{
+		{
+			"NAGIOSTIME",
+			`%{NAGIOSTIME}`,
+			"[1234567890]",
+			map[string]string{
+				"timestamp": "1234567890",
+			},
+		},
+		{
+			"NAGIOS_SERVICE_ALERT",
+			`%{NAGIOS_SERVICE_ALERT}`,
+			"SERVICE ALERT: localhost;HTTP;CRITICAL;HARD;3;Connection refused",
+			map[string]string{
+				"nagios.log.type":       "SERVICE ALERT",
+				"host.hostname":         "localhost",
+				"service.name":          "HTTP",
+				"service.state":         "CRITICAL",
+				"nagios.log.state_type": "HARD",
+				"nagios.log.attempt":    "3",
+				"message":               "Connection refused",
+			},
+		},
+		{
+			"NAGIOS_HOST_ALERT",
+			`%{NAGIOS_HOST_ALERT}`,
+			"HOST ALERT: web01;DOWN;SOFT;1;PING CRITICAL",
+			map[string]string{
+				"nagios.log.type":       "HOST ALERT",
+				"host.hostname":         "web01",
+				"service.state":         "DOWN",
+				"nagios.log.state_type": "SOFT",
+				"nagios.log.attempt":    "1",
+				"message":               "PING CRITICAL",
+			},
+		},
+		{
+			"NAGIOSLOGLINE",
+			`%{NAGIOSLOGLINE}`,
+			"[1234567890] SERVICE ALERT: localhost;HTTP;CRITICAL;HARD;3;Connection refused",
+			map[string]string{
+				"timestamp":             "1234567890",
+				"nagios.log.type":       "SERVICE ALERT",
+				"host.hostname":         "localhost",
+				"service.name":          "HTTP",
+				"service.state":         "CRITICAL",
+				"nagios.log.state_type": "HARD",
+				"nagios.log.attempt":    "3",
+				"message":               "Connection refused",
+			},
+		},
+		{
+			"NAGIOS_EC_LINE_PROCESS_SERVICE_CHECK_RESULT",
+			`%{NAGIOS_EC_LINE_PROCESS_SERVICE_CHECK_RESULT}`,
+			"EXTERNAL COMMAND: PROCESS_SERVICE_CHECK_RESULT;web01;Disk;0;OK - free space",
+			map[string]string{
+				"nagios.log.type":         "EXTERNAL COMMAND",
+				"nagios.log.command":      "PROCESS_SERVICE_CHECK_RESULT",
+				"host.hostname":           "web01",
+				"service.name":            "Disk",
+				"service.state":           "0",
+				"nagios.log.check_result": "OK - free space",
+			},
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.Name, func(t *testing.T) {
+			g, err := grok.NewWithPatterns(patterns.Nagios)
+			require.NoError(t, err)
+			require.NoError(t, g.Compile(tt.Pattern, false))
+
+			res, err := g.ParseString(tt.Text)
+			require.NoError(t, err)
+
+			if len(tt.ExpectedMatches) > len(res) {
+				for k := range tt.ExpectedMatches {
+					_, ok := res[k]
+					assert.Truef(t, ok, "key not found %q", k)
+				}
+			}
+
+			for k, v := range tt.ExpectedMatches {
+				val, found := res[k]
+				require.True(t, found, "Key %q not found", k)
+				require.Equalf(t, v, val, "Values not equal for key. Expected %q, have %q", k, v, val)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Port Nagios grok patterns from elastic/elasticsearch `ecs-v1/nagios`
- Register `patterns.Nagios` in `NewComplete`
- Add unit tests for representative Nagios log lines

Fixes #17

## Test plan
- [x] `go test ./patterns_test/ -run Nagios`
- [ ] `go test ./...`